### PR TITLE
Add support for using a bedgraph as a pileup, instead of calculating from a bam

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,18 @@ followed by the arguments you need:
 | Name |  Description | Default |
 |---|---|---|
 | `-runType` | Run type if multiple files are given. "top-down" or "bottom-up" | bottom-up |
-| `-bamIn`| Input Sam or Bam alignment file. | |
+| `-bamIn`| Input Sam or Bam alignment file. Cannot be used with -pileupIn. | |
+| `-pileupIn`| Input bedGraph pileup. Cannot be used with -pileupIn. | |
 | `-chrFilter` | Chromosome Filter File. See Below. | |
 | `-signalOut`| Output Signal File. Enables signal output. | |
 | `-signalOutType`| Output "raw" and "smoothed" Pile-Up data to the signal file. | smoothed |
 | `-signalOutFormat`| Output Signal File to "wig" or "bed-graph" file | bed-graph |
 | `-peaksOut`| Output peaks bed file. | |
-| `-strand`| Strand to count during pile-up. "plus", "minus", or "both" | both |
+| `-strand`| Strand to count during pile-up. "plus", "minus", or "both". Ignored if not using -bamIn. | both |
+| `-forwardShift`| During pile-up, shift the forward strand by this amount. Can be positive or negative. Ignored if not using -bamIn. | 0 |
+| `-reverseShift`| During pile-up, shift the reverse strand by this amount. Can be positive or negative. Ignored if not using -bamIn. | 0 |
+| `-pileUpAlgorithm`| Algorithm used to select values during pile-up. "start", "midpoint", or "length". Ignored if not using -bamIn. | start |
 | `-signalResolution`| Number of decimal places to keep in outputted signal values. | 1 |
-| `-forwardShift`| During pile-up, shift the forward strand by this amount. Can be positive or negative. | 0 |
-| `-reverseShift`| During pile-up, shift the reverse strand by this amount. Can be positive or negative. | 0 |
-| `-pileUpAlgorithm`| Algorithm used to select values during pile-up. "start", "midpoint", or "length" | start |
 | `-smoothingFactor` | Smoothing factor for calculating PDF for pile-up data during peaks step. | 50.0 |
 | `-threshold`| Threshold used during peak calling. | 6.0 |
 | `-fitMode`| Sub-peak fitting modes. "skew" or "standard" | skew |
@@ -91,6 +92,22 @@ For example, the following will calculate peaks for chromosome 1, 10-15 million 
 chr1
 chr2    10000000-15000000
 chr3    0-3000000
+```
+
+## Output
+
+### Peaks bed file
+
+The output peaks file contains the locations of fitted gaussian curves in BED format with the amplitude and skew (if applicable). A random peak name is assigned to each peak. The current format of the output peaks file is:
+
+When -fitMode is set to "skew":
+```
+chrom   start   end peak_name   amplitude#skew
+```
+
+When -fitMode is set to "standard":
+```
+chrom   start   end peak_name   amplitude
 ```
 
 ## For Contributors

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -7,20 +7,23 @@ import runner.ZRunConfig
 import step.*
 import util.*
 import runner.*
-import java.nio.file.Files
+import java.lang.IllegalStateException
 import java.nio.file.Path
-import kotlin.streams.toList
 
 
-class ZPeaksCommand(val run: (RunType, ZRunConfig) -> Unit = ::run): CliktCommand() {
+class ZPeaksCommand(val run: (RunType, ZRunConfig, Boolean) -> Unit = ::run): CliktCommand() {
     private val runType: RunType by option("-runType",
         help="Type of run. Relates to the way data from bam files are aggregated.")
         .choice(RunType.values().associateBy { it.lowerHyphenName })
         .default(RunType.BOTTOM_UP)
-    private val bamsIn: List<Path> by option("-bamIn", help="Input Bam alignment file")
+    private val bamsIn: List<Path> by option("-bamIn", help="Input Bam alignment file. " +
+            "Cannot be used with -pileupIn.")
         .path(exists = true)
         .multiple()
-        .validate { require(it.isNotEmpty()) { "At least one path must be given" } }
+    private val pileupsIn: List<Path> by option("-pileupIn", help="Input bedGraph pileup. " +
+            "Cannot be used with -bamIn.")
+        .path(exists = true)
+        .multiple()
     private val chrFilterPath: Path? by option("-chrFilter", help="Chromosome Filter file. An optional new-line " +
             "delimited file containing the chromosome that we will analyze. Others will be ignored.")
         .path(exists = true)
@@ -32,19 +35,20 @@ class ZPeaksCommand(val run: (RunType, ZRunConfig) -> Unit = ::run): CliktComman
         .choice(SignalOutputFormat.values().associateBy { it.lowerHyphenName })
         .default(SignalOutputFormat.BED_GRAPH)
     private val peaksOut: Path? by option("-peaksOut", help="Output Peaks bed file").path()
-    private val strands: List<Strand> by option("-strand", help="Strand to count during pile-up")
+    private val strands: List<Strand> by option("-strand", help="Strand to count during pile-up. " +
+            "Ignored if not using -bamIn.")
         .choice(Strand.values().associateBy { it.lowerHyphenName })
         .multiple(listOf(Strand.BOTH))
     private val forwardShifts by option("-forwardShift", help="During pile-up, shift the " +
-            "forward strand by this amount. Can be positive or negative. Default 0.")
+            "forward strand by this amount. Ignored if not using -bamIn. Can be positive or negative. Default 0.")
         .int()
         .multiple(listOf(0))
     private val reverseShifts by option("-reverseShift", help="During pile-up, shift the " +
-            "reverse strand by this amount. Can be positive or negative. Default 0.")
+            "reverse strand by this amount. Ignored if using -bamIn. Can be positive or negative. Default 0.")
         .int()
         .multiple(listOf(0))
     private val pileUpAlgorithms: List<PileUpAlgorithm> by option("-pileUpAlgorithm",
-        help="Algorithm used to select values during pile up.")
+        help="Algorithm used to select values during pile up. Ignored if not using -bamIn.")
         .choice(PileUpAlgorithm.values().associateBy { it.lowerHyphenName })
         .multiple(listOf(PileUpAlgorithm.START))
     private val signalResolution: Int by option("-signalResolution",
@@ -64,32 +68,56 @@ class ZPeaksCommand(val run: (RunType, ZRunConfig) -> Unit = ::run): CliktComman
     override fun run() {
         if (signalOutPath == null && peaksOut == null)
             throw Exception("One of the following must be set: -signalOut or -peaksOut")
+        if ((bamsIn.isEmpty() && pileupsIn.isEmpty()) || (!bamsIn.isEmpty() && !pileupsIn.isEmpty()))
+            throw Exception("One (and only one) of the following must be set: -bamIn or -pileupIn")
         val signalOut =
             if (signalOutPath != null) SignalOutput(signalOutPath!!, signalOutType, signalOutFormat, signalResolution)
             else null
 
-        val pileUpInputs = mutableListOf<PileUpInput>()
-        for ((samIndex, sam) in bamsIn.withIndex()) {
-            val strand = strands.getOrElse(samIndex) { strands.last() }
-            val pileUpAlgorithm = pileUpAlgorithms.getOrElse(samIndex) { pileUpAlgorithms.last() }
-            val forwardShift = forwardShifts.getOrElse(samIndex) { forwardShifts.last() }
-            val reverseShift = reverseShifts.getOrElse(samIndex) { reverseShifts.last() }
-            val pileUpOptions = PileUpOptions(strand, pileUpAlgorithm, forwardShift, reverseShift)
-            pileUpInputs += PileUpInput(sam, pileUpOptions)
+        val chrFilter = if (chrFilterPath != null) parseChrFilter(chrFilterPath!!) else null
+
+        val pileUpRunner: PileUpRunner = if (!bamsIn.isEmpty()) {
+            val pileUpInputs = mutableListOf<PileUpInput>()
+            for ((samIndex, sam) in bamsIn.withIndex()) {
+                val strand = strands.getOrElse(samIndex) { strands.last() }
+                val pileUpAlgorithm = pileUpAlgorithms.getOrElse(samIndex) { pileUpAlgorithms.last() }
+                val forwardShift = forwardShifts.getOrElse(samIndex) { forwardShifts.last() }
+                val reverseShift = reverseShifts.getOrElse(samIndex) { reverseShifts.last() }
+                val pileUpOptions = PileUpOptions(strand, pileUpAlgorithm, forwardShift, reverseShift)
+                pileUpInputs += PileUpInput(sam, pileUpOptions)
+            }
+            BamPileUpRunner(pileUpInputs)
+        } else if (!pileupsIn.isEmpty()) {
+            when {
+                pileupsIn.all { isBigWig(it) } -> throw Exception("bigWig support is not supported yet")
+                pileupsIn.all { isBedGraph(it) } -> BedGraphPileUpRunner(pileupsIn)
+                else -> throw Exception("All of -pileupIn must be a bedGraph")
+            }
+        } else {
+            // Checked at start
+            throw IllegalStateException()
         }
 
-        val chrFilter = if (chrFilterPath != null) parseChrFilter(chrFilterPath!!) else null
-        val runConfig = ZRunConfig(pileUpInputs, chrFilter, signalOut, peaksOut, smoothing,
+        val isSingle = if (!bamsIn.isEmpty()) {
+            bamsIn.size == 1
+        } else if (!pileupsIn.isEmpty()) {
+            pileupsIn.size == 1
+        } else {
+            // Checked at start
+            throw IllegalStateException()
+        }
+
+        val runConfig = ZRunConfig(pileUpRunner, chrFilter, signalOut, peaksOut, smoothing,
             threshold, fitMode, parallelism)
-        run(runType, runConfig)
+        run(runType, runConfig, isSingle)
     }
 }
 
 enum class RunType { TOP_DOWN, BOTTOM_UP }
 
-fun run(runType: RunType, config: ZRunConfig) {
+fun run(runType: RunType, config: ZRunConfig, isSingle: Boolean) {
     val runner = when {
-        config.pileUpInputs.size == 1 -> SingleFileZRunner(config)
+        isSingle -> SingleFileZRunner(config)
         runType == RunType.BOTTOM_UP -> BottomUpZRunner(config)
         else -> TopDownZRunner(config)
     }

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -95,7 +95,7 @@ class ZPeaksCommand(val run: (RunType, ZRunConfig, Boolean) -> Unit = ::run): Cl
             }
         } else {
             // Checked at start
-            throw IllegalStateException()
+            throw IllegalStateException("Both bamsIn and pileupsIn are empty. (This is a bug.)")
         }
 
         val isSingle = if (!bamsIn.isEmpty()) {
@@ -104,7 +104,7 @@ class ZPeaksCommand(val run: (RunType, ZRunConfig, Boolean) -> Unit = ::run): Cl
             pileupsIn.size == 1
         } else {
             // Checked at start
-            throw IllegalStateException()
+            throw IllegalStateException("Both bamsIn and pileupsIn are empty. (This is a bug.)")
         }
 
         val runConfig = ZRunConfig(pileUpRunner, chrFilter, signalOut, peaksOut, smoothing,

--- a/src/main/kotlin/runner/BottomUp.kt
+++ b/src/main/kotlin/runner/BottomUp.kt
@@ -11,8 +11,7 @@ class BottomUpZRunner(runConfig: ZRunConfig) : ZRunner("Bottom-Up", runConfig) {
         log.info { "Creating aggregate pile-up for $chr..." }
         val aggregatePileUpData = FloatArray(chrLength)
         var sum = 0.0
-        for (pileUpInput in pileUpInputs) {
-            val pileUp = runPileUp(pileUpInput.bam, chr, chrLength, range, pileUpInput.options)
+        for (pileUp in pileUpRunner.getPileUps(chr, chrLength, range)) {
             for (index in 0 until chrLength) {
                 val value = pileUp.scaledValue(index)
                 aggregatePileUpData[index] += value

--- a/src/main/kotlin/runner/SingleFile.kt
+++ b/src/main/kotlin/runner/SingleFile.kt
@@ -5,7 +5,6 @@ import step.*
 class SingleFileZRunner(runConfig: ZRunConfig) : ZRunner("Single File", runConfig) {
 
     override fun pileUp(chr: String, chrLength: Int, range: IntRange): PileUp = with(runConfig) {
-        val pileUpInput = pileUpInputs[0]
-        return runPileUp(pileUpInput.bam, chr, chrLength, range, pileUpInput.options)
+        return pileUpRunner.getPileUps(chr, chrLength, range).toList()[0]
     }
 }

--- a/src/main/kotlin/runner/TopDown.kt
+++ b/src/main/kotlin/runner/TopDown.kt
@@ -19,8 +19,7 @@ class TopDownZRunner(runConfig: ZRunConfig) : ZRunner("Top-Down", runConfig) {
         val allPeaks = mutableListOf<List<Region>>()
         allCurrentChrPeaks = allPeaks
 
-        for (pileUpInput in pileUpInputs) {
-            val pileUp = runPileUp(pileUpInput.bam, chr, chrLength, range, pileUpInput.options)
+        for (pileUp in pileUpRunner.getPileUps(chr, chrLength, range)) {
             val pdf = pdf(pileUp, smoothing)
             val peaks = callPeaks(pdf, threshold)
             allPeaks += peaks

--- a/src/main/kotlin/step/BamPileUp.kt
+++ b/src/main/kotlin/step/BamPileUp.kt
@@ -1,0 +1,148 @@
+package step
+
+import htsjdk.samtools.*
+import model.*
+import mu.KotlinLogging
+import util.*
+import java.nio.file.Path
+import kotlin.math.sqrt
+
+
+private val log = KotlinLogging.logger {}
+
+enum class PileUpAlgorithm {
+    // Use only the start of each alignment
+    START,
+    // Use the mid-point between start and end for each alignment. *Paired End Only
+    MID_POINT,
+    // Use every BP between start and end for each alignment. *Paired End Only
+    LENGTH
+}
+
+// When using the LENGTH pile-up algorithm we will not include values for lengths that are larger than this value.
+// They are most likely junk and will waste resources.
+const val LENGTH_LIMIT = 100_000
+
+/**
+ * @param strand: Strand that we want to count using pile-up algorithm
+ * @param pileUpAlgorithm: Algorithm we use to choose the values that we pile up.
+ * @param forwardShift: shifts forward (plus) strand by this amount
+ * @param reverseShift: shifts reverse (minus) strand by this amount
+ */
+data class PileUpOptions(
+    val strand: Strand,
+    val pileUpAlgorithm: PileUpAlgorithm,
+    val forwardShift: Int = 0,
+    val reverseShift: Int = 0
+)
+
+data class BamPileUpRunner(
+    val pileUpInputs: List<PileUpInput>
+) : PileUpRunner {
+    var prepped = false
+
+    fun ensurePrepped() {
+        if (!prepped) {
+            getChromsWithBounds()
+        }
+    }
+    override fun getChromsWithBounds(chrFilter: Map<String, IntRange?>?): Map<String, ChromBounds> {
+        val ret = prepBams(pileUpInputs.map { it.bam }, chrFilter)
+        prepped = true
+        return ret
+    }
+
+    override fun getPileUps(chr: String, chrLength: Int, range: IntRange): Sequence<PileUp> = sequence {
+        ensurePrepped()
+        for (pileUpInput in pileUpInputs) {
+            yield(runPileUp(pileUpInput.bam, chr, chrLength, range, pileUpInput.options))
+        }
+    }
+}
+
+
+/**
+ * Reads a SAM or BAM file and creates a pile-up representation in memory.
+ *
+ * @return the in-memory pile-up
+ */
+fun runPileUp(bam: Path, chr: String, chrLength: Int, range: IntRange, options: PileUpOptions): PileUp {
+    log.info { "Performing pile-up for chromosome $chr on alignment $bam..." }
+    val values = FloatArray(chrLength) { 0.0F }
+    var sum = 0L
+    val pileUpBounds = 0 until chrLength
+    SamReaderFactory.make().validationStringency(ValidationStringency.SILENT).open(bam).use { reader ->
+        reader.query(chr, 0, 0, false).forEach { record ->
+            // If we're only using plus strand values and this record is a plus strand and
+            // visa versa for minus strand, continue.
+            if ((options.strand == Strand.PLUS && record.readNegativeStrandFlag) ||
+                    (options.strand == Strand.MINUS && !record.readNegativeStrandFlag)
+            ) return@forEach
+
+            // If the record is junk, continue
+            if (record.end < record.start || record.end - record.start > LENGTH_LIMIT) return@forEach
+            if (record.referenceName.equals("*")) return@forEach
+
+            val start = pileUpStart(record, pileUpBounds, options.forwardShift, options.reverseShift)
+            when (options.pileUpAlgorithm) {
+                PileUpAlgorithm.START -> {
+                    values[start]++
+                    sum++
+                }
+                PileUpAlgorithm.MID_POINT -> {
+                    val end = pileUpEnd(record, pileUpBounds, options.forwardShift, options.reverseShift)
+                    val midPoint = (start + end) / 2
+                    values[midPoint]++
+                    sum++
+                }
+                PileUpAlgorithm.LENGTH -> {
+                    val end = pileUpEnd(record, pileUpBounds, options.forwardShift, options.reverseShift)
+                    val length = end - start
+                    for (i in start until end) {
+                        values[i]++
+                    }
+                    sum += length
+                }
+            }
+        }
+    }
+
+    log.info { "Pile-up complete with sum $sum" }
+    return PileUp(values, chr, chrLength, range, sum.toDouble())
+}
+
+/**
+ * Calculate the "start" value for our pile-up algorithm for the given record and settings.
+ *
+ * This start will actually be the record's end it's strand is minus
+ */
+private fun pileUpStart(record: SAMRecord, bounds: IntRange, forwardShift: Int, reverseShift: Int): Int {
+    return if (!record.readNegativeStrandFlag) {
+        (record.start + forwardShift).withinBounds(bounds)
+    } else {
+        (record.end + reverseShift).withinBounds(bounds)
+    }
+}
+
+/**
+ * Calculate the "end" value for our pile-up algorithm for the given SAM record and settings.
+ *
+ * This end will actually be the record's start it's strand is minus
+ */
+private fun pileUpEnd(record: SAMRecord, bounds: IntRange, forwardShift: Int, reverseShift: Int): Int {
+    return if (!record.readNegativeStrandFlag) {
+        (record.end + reverseShift).withinBounds(bounds)
+    } else {
+        (record.start + forwardShift).withinBounds(bounds)
+    }
+}
+
+/**
+ * @returns: if < start: start, if > end: end, else value
+ */
+private fun Int.withinBounds(bounds: IntRange) =
+    when {
+        this < bounds.start -> bounds.start
+        this > bounds.endInclusive -> bounds.endInclusive
+        else -> this
+    }

--- a/src/main/kotlin/step/BedGraphPileUp.kt
+++ b/src/main/kotlin/step/BedGraphPileUp.kt
@@ -1,0 +1,208 @@
+package step
+
+import model.*
+import mu.KotlinLogging
+import util.logProgress
+import java.io.RandomAccessFile
+import java.nio.file.Path
+
+
+private val log = KotlinLogging.logger {}
+
+data class BedGraphPileUpRunner(
+    val bedGraphs: List<Path>
+) : PileUpRunner {
+    // pair is size, offset
+    val chromOffsets: Map<String, Map<Path, Pair<Int, Long>>> by lazy {
+        log.info { "Indexing chromosome offsets in pileup bedgraphs." }
+        // We're doing this for two reasons:
+        // 1) We need to all the chromosomes and their sizes
+        // 2) We want to index the boundaries in the file for faster access
+        //
+        // This approach uses a binary tree-like approach to find the file offsets between
+        val ret = mutableMapOf<String, MutableMap<Path, Pair<Int, Long>>>()
+        for (bedGraph in bedGraphs) {
+            val file = RandomAccessFile(bedGraph.toFile(), "r")
+            var headerEnd = file.filePointer
+            while (true) {
+                val r = file.readLine()
+                if (!r.startsWith("track")) {
+                    break
+                }
+                headerEnd = file.filePointer
+            }
+            val fileEnd = file.length()
+            val offsets = mutableMapOf<String, Long>()
+            getOffsets(file, headerEnd, fileEnd, offsets)
+            val sizes = getSizes(file, offsets)
+            for (chr in offsets.keys) {
+                val offset = offsets[chr]!!
+                val size = sizes[chr]!!
+                ret.getOrPut(chr) { mutableMapOf() }.putIfAbsent(bedGraph, Pair(size, offset))
+            }
+        }
+        ret
+    }
+
+    fun getOffsets(file: RandomAccessFile, offsetStart: Long, offsetEnd: Long, offsets: MutableMap<String, Long>, passedLeft: String? = null, passedRight: String? = null) {
+        // This wouldn't be a valid file anyways (maybe empty), but this prevents errors/unexpected behavior
+        if (offsetEnd - offsetStart < 2) {
+            return
+        }
+        val left = if (passedLeft != null) {
+            passedLeft
+        } else {
+            file.seek(offsetStart)
+            val left = file.readLine().split("\t")[0]
+            offsets[left] = offsetStart
+            left
+        }
+        val right = if (passedRight != null) {
+            passedRight
+        } else {
+            file.seek(offsetEnd)
+            while (true) {
+                val nextOffset = file.filePointer - 2
+                file.seek(nextOffset)
+                if (nextOffset <= offsetStart) {
+                    return
+                }
+                if (file.readByte() == '\n'.toByte()) {
+                    break
+                }
+            }
+            val line = file.readLine()
+            line.split("\t")[0]
+        }
+        if (left == right) {
+            return
+        }
+        file.seek((offsetEnd - offsetStart) / 2 + offsetStart)
+        while (true) {
+            val nextOffset = file.filePointer - 2
+            file.seek(nextOffset)
+            if (nextOffset <= offsetStart) {
+                break
+            }
+            if (file.readByte() == '\n'.toByte()) {
+                break
+            }
+        }
+        val mid = file.filePointer
+        if (mid == offsetStart) {
+            // The current section is too small to subdivide
+            // Just read the entire section
+            file.seek(offsetStart)
+            var currentOffset = offsetStart
+            var lastchrom: String? = null
+            while (true) {
+                currentOffset = file.filePointer
+                if (currentOffset >= offsetEnd) {
+                    return
+                }
+                val r = file.readLine()?.split("\t") ?: return
+                if (lastchrom != r[0] && lastchrom != null) {
+                    offsets[r[0]] = currentOffset
+                }
+                lastchrom = r[0]
+            }
+        }
+        while (true) {
+            val nextOffset = file.filePointer - 2
+            file.seek(nextOffset)
+            if (nextOffset <= offsetStart) {
+                break
+            }
+            if (file.readByte() == '\n'.toByte()) {
+                break
+            }
+        }
+        val midright = file.readLine().split("\t")[0]
+        assert(mid == file.filePointer)
+        val midleft = file.readLine().split("\t")[0]
+        if (midright != midleft) {
+            offsets[midleft] = mid
+        }
+        getOffsets(file, offsetStart, mid, offsets, left, midright)
+        getOffsets(file, mid, offsetEnd, offsets, midleft, right)
+    }
+
+    fun getSizes(file: RandomAccessFile, offsets: Map<String, Long>): Map<String, Int> {
+        val sizes = mutableMapOf<String, Int>()
+        var lastchrom: String? = null
+        offsets.entries.sortedBy { it.value }.forEach {
+            if (lastchrom == null) {
+                lastchrom = it.key
+                return@forEach
+            }
+            file.seek(it.value)
+            while (true) {
+                val nextOffset = file.filePointer - 2
+                file.seek(nextOffset)
+                if (file.readByte() == '\n'.toByte()) {
+                    break
+                }
+            }
+            sizes[lastchrom!!] = file.readLine().split("\t")[2].toInt()
+            lastchrom = it.key
+        }
+        file.seek(file.length())
+        while (true) {
+            val nextOffset = file.filePointer - 2
+            file.seek(nextOffset)
+
+            if (file.readByte() == '\n'.toByte()) {
+                break
+            }
+        }
+        sizes[lastchrom!!] = file.readLine().split("\t")[2].toInt()
+        return sizes
+    }
+
+    override fun getChromsWithBounds(chrFilter: Map<String, IntRange?>?): Map<String, ChromBounds> {
+        return chromOffsets.entries
+            .filter { chrFilter == null || chrFilter.contains(it.key) }
+            .map {
+                val chr = it.key
+                val map = it.value
+                var length = 0
+                for ((_, pair) in map) {
+                    val (size, _) = pair
+                    length = maxOf(length, size)
+                }
+                val range =
+                    if (chrFilter?.get(chr) != null) chrFilter.getValue(chr)!!
+                    else (0 until length)
+                chr to ChromBounds(chr, length, range)
+            }.toMap()
+    }
+
+    override fun getPileUps(chr: String, chrLength: Int, range: IntRange): Sequence<PileUp> = sequence {
+        for (bedGraph in bedGraphs) {
+            log.info { "Reading pile-up for chromosome $chr on file $bedGraph..." }
+            val values = FloatArray(chrLength) { 0.0F }
+            var sum = 0.0
+            val file = RandomAccessFile(bedGraph.toFile(), "r")
+            file.seek(chromOffsets.getValue(chr).getValue(bedGraph).second)
+            logProgress("BedGraphPileupReader", chrLength) {tracker ->
+                while (true) {
+                    val line = file.readLine() ?: break
+                    val split = line.split("\t")
+                    val chrom = split[0]
+                    if (chrom != chr) break
+                    val start = split[1].toInt()
+                    val end = split[2].toInt()
+                    val value = split[3].toFloat()
+                    val length = end - start
+                    for (base in start until end) {
+                        values[base] += value
+                    }
+                    sum += value * length
+
+                    tracker.set(end)
+                }
+            }
+            yield(PileUp(values, chr, chrLength, range, sum))
+        }
+    }
+}

--- a/src/main/kotlin/step/PileUp.kt
+++ b/src/main/kotlin/step/PileUp.kt
@@ -1,39 +1,21 @@
 package step
 
-import htsjdk.samtools.*
-import model.*
-import mu.KotlinLogging
-import util.*
+import model.ChromBounds
+import model.SignalData
 import java.nio.file.Path
 import kotlin.math.sqrt
 
-
-private val log = KotlinLogging.logger {}
-
-enum class PileUpAlgorithm {
-    // Use only the start of each alignment
-    START,
-    // Use the mid-point between start and end for each alignment. *Paired End Only
-    MID_POINT,
-    // Use every BP between start and end for each alignment. *Paired End Only
-    LENGTH
-}
-
-// When using the LENGTH pile-up algorithm we will not include values for lengths that are larger than this value.
-// They are most likely junk and will waste resources.
-const val LENGTH_LIMIT = 100_000
-
 class PileUp(
-    // Pile-up values in chromosome.
-    private val values: FloatArray,
-    // Chromosome as named in alignment file
-    override val chr: String,
-    // Chromosome length pulled directly from BAM File
-    val chrLength: Int,
-    // Chromosome range to be used downstream
-    override val range: IntRange,
-    // Sum of all pile-up values in chromosome calculated on the fly and cached for efficiency
-    val sum: Double
+        // Pile-up values in chromosome.
+        private val values: FloatArray,
+        // Chromosome as named in alignment file
+        override val chr: String,
+        // Chromosome length pulled directly from BAM File
+        val chrLength: Int,
+        // Chromosome range to be used downstream
+        override val range: IntRange,
+        // Sum of all pile-up values in chromosome calculated on the fly and cached for efficiency
+        val sum: Double
 ) : SignalData {
     override operator fun get(bp: Int): Float = values[bp]
 
@@ -41,101 +23,8 @@ class PileUp(
     fun scaledValue(bp: Int): Float = this[bp] / scalingFactor
 }
 
-/**
- * @param strand: Strand that we want to count using pile-up algorithm
- * @param pileUpAlgorithm: Algorithm we use to choose the values that we pile up.
- * @param forwardShift: shifts forward (plus) strand by this amount
- * @param reverseShift: shifts reverse (minus) strand by this amount
- */
-data class PileUpOptions(
-    val strand: Strand,
-    val pileUpAlgorithm: PileUpAlgorithm,
-    val forwardShift: Int = 0,
-    val reverseShift: Int = 0
-)
+interface PileUpRunner {
+    fun getChromsWithBounds(chrFilter: Map<String, IntRange?>? = null): Map<String, ChromBounds>
 
-/**
- * Reads a SAM or BAM file and creates a pile-up representation in memory.
- *
- * @return the in-memory pile-up
- */
-fun runPileUp(bam: Path, chr: String, chrLength: Int, range: IntRange, options: PileUpOptions): PileUp {
-    log.info { "Performing pile-up for chromosome $chr on alignment $bam..." }
-    val values = FloatArray(chrLength) { 0.0F }
-    var sum = 0L
-    val pileUpBounds = 0 until chrLength
-    SamReaderFactory.make().validationStringency(ValidationStringency.SILENT).open(bam).use { reader ->
-        reader.query(chr, 0, 0, false).forEach { record ->
-            // If we're only using plus strand values and this record is a plus strand and
-            // visa versa for minus strand, continue.
-            if ((options.strand == Strand.PLUS && record.readNegativeStrandFlag) ||
-                (options.strand == Strand.MINUS && !record.readNegativeStrandFlag)
-            ) return@forEach
-
-            // If the record is junk, continue
-            if (record.end < record.start || record.end - record.start > LENGTH_LIMIT) return@forEach
-	    if (record.referenceName.equals("*")) return@forEach
-
-            val start = pileUpStart(record, pileUpBounds, options.forwardShift, options.reverseShift)
-            when (options.pileUpAlgorithm) {
-                PileUpAlgorithm.START -> {
-                    values[start]++
-                    sum++
-                }
-                PileUpAlgorithm.MID_POINT -> {
-                    val end = pileUpEnd(record, pileUpBounds, options.forwardShift, options.reverseShift)
-                    val midPoint = (start + end) / 2
-                    values[midPoint]++
-                    sum++
-                }
-                PileUpAlgorithm.LENGTH -> {
-                    val end = pileUpEnd(record, pileUpBounds, options.forwardShift, options.reverseShift)
-                    val length = end - start
-                    for (i in start until end) {
-                        values[i]++
-                    }
-                    sum += length
-                }
-            }
-        }
-    }
-
-    log.info { "Pile-up complete with sum $sum" }
-    return PileUp(values, chr, chrLength, range, sum.toDouble())
+    fun getPileUps(chr: String, chrLength: Int, range: IntRange): Sequence<PileUp>
 }
-
-/**
- * Calculate the "start" value for our pile-up algorithm for the given record and settings.
- *
- * This start will actually be the record's end it's strand is minus
- */
-private fun pileUpStart(record: SAMRecord, bounds: IntRange, forwardShift: Int, reverseShift: Int): Int {
-    return if (!record.readNegativeStrandFlag) {
-        (record.start + forwardShift).withinBounds(bounds)
-    } else {
-        (record.end + reverseShift).withinBounds(bounds)
-    }
-}
-
-/**
- * Calculate the "end" value for our pile-up algorithm for the given SAM record and settings.
- *
- * This end will actually be the record's start it's strand is minus
- */
-private fun pileUpEnd(record: SAMRecord, bounds: IntRange, forwardShift: Int, reverseShift: Int): Int {
-    return if (!record.readNegativeStrandFlag) {
-        (record.end + reverseShift).withinBounds(bounds)
-    } else {
-        (record.start + forwardShift).withinBounds(bounds)
-    }
-}
-
-/**
- * @returns: if < start: start, if > end: end, else value
- */
-private fun Int.withinBounds(bounds: IntRange) =
-    when {
-        this < bounds.start -> bounds.start
-        this > bounds.endInclusive -> bounds.endInclusive
-        else -> this
-    }

--- a/src/test/kotlin/AppTests.kt
+++ b/src/test/kotlin/AppTests.kt
@@ -20,9 +20,8 @@ class AppTests {
         val testDir = Files.createTempDirectory("zpeaks_test")
         var peaksOut = testDir.resolve(peaksFilename)
 
-        val runConfig = ZRunConfig(listOf(PileUpInput(TEST_BAM_PATH, PileUpOptions(Strand.BOTH, PileUpAlgorithm.START))))
+        val runConfig = ZRunConfig(BamPileUpRunner(listOf(PileUpInput(TEST_BAM_PATH, PileUpOptions(Strand.BOTH, PileUpAlgorithm.START)))))
         val zRunner = SingleFileZRunner(runConfig)
-        zRunner.prepBams()
         val pileUp = zRunner.pileUp(CHR_22, CHR_22_SIZE, 10_000_000 until 15_000_000)
 
         val pdf = zRunner.pdf(pileUp)

--- a/src/test/kotlin/BedGraphPileUpRunnerTests.kt
+++ b/src/test/kotlin/BedGraphPileUpRunnerTests.kt
@@ -1,0 +1,40 @@
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import step.BedGraphPileUpRunner
+import util.MULTICHROM_PILEUP_BEDGRAPH
+import util.isBedGraph
+
+class BedGraphPileUpRunnerTests {
+
+    @Test
+    fun `Test Chrom Offsets`() {
+        val runner = BedGraphPileUpRunner(listOf(MULTICHROM_PILEUP_BEDGRAPH))
+        val chromOffsets = runner.chromOffsets
+        val expected = listOf<Triple<String, Int, Long>>(
+            Triple("chr20", 64332156, 20),
+            Triple("chr21", 46700008, 21417232),
+            Triple("chr22", 50808468, 29776620)
+        )
+        // Test in reverse since later offsets will cause earlier sizes to be wrong
+        for (chr in expected.reversed()) {
+            Assertions.assertThat(chromOffsets).containsKey(chr.first)
+            val offsets = chromOffsets[chr.first]!!
+            Assertions.assertThat(offsets).containsKey(MULTICHROM_PILEUP_BEDGRAPH)
+            val offsetsBedGraph = offsets[MULTICHROM_PILEUP_BEDGRAPH]
+            Assertions.assertThat(offsetsBedGraph).isEqualTo(Pair(chr.second, chr.third))
+        }
+    }
+
+    @Test
+    fun `Test getPileUps`() {
+        val runner = BedGraphPileUpRunner(listOf(MULTICHROM_PILEUP_BEDGRAPH))
+        val chrsWithBounds = runner.getChromsWithBounds()
+        val pileUps = runner.getPileUps("chr22", chrsWithBounds["chr22"]!!.length, SAMPLE_RANGE_LARGE).toList()
+        Assertions.assertThat(pileUps.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `Test isBedGraph`() {
+        Assertions.assertThat(isBedGraph(MULTICHROM_PILEUP_BEDGRAPH)).isTrue()
+    }
+}

--- a/src/test/kotlin/CliTests.kt
+++ b/src/test/kotlin/CliTests.kt
@@ -15,7 +15,7 @@ class CliTests {
         val signalOut = testDir.resolve("testSignalOut.bed")
         val peaksOut = testDir.resolve("testPeaksOut.bed")
 
-        val mockRun = spyk<(RunType, ZRunConfig) -> Unit>()
+        val mockRun = spyk<(RunType, ZRunConfig, Boolean) -> Unit>()
         val args =
             """
             -bamIn=$MULTI_BAM_1_PATH -strand=both -pileUpAlgorithm=start -forwardShift=5 -reverseShift=10
@@ -29,10 +29,10 @@ class CliTests {
         ZPeaksCommand(run = mockRun).main(args)
 
         val expectedRunConfig = ZRunConfig(
-            pileUpInputs = listOf(
+            pileUpRunner = BamPileUpRunner(listOf(
                 PileUpInput(MULTI_BAM_1_PATH, PileUpOptions(Strand.BOTH, PileUpAlgorithm.START, 5, 10)),
                 PileUpInput(MULTI_BAM_2_PATH, PileUpOptions(Strand.PLUS, PileUpAlgorithm.LENGTH, -5, 15))
-            ),
+            )),
             chrFilter = mapOf("chr22" to (30000000 until 30500000)),
             signalOut = SignalOutput(signalOut, SignalOutputType.RAW, SignalOutputFormat.WIG, signalResolution = 2),
             peaksOut = peaksOut,
@@ -40,7 +40,7 @@ class CliTests {
             threshold = 7.0,
             parallelism = 4
         )
-        verify { mockRun(any(), expectedRunConfig) }
+        verify { mockRun(any(), expectedRunConfig, false) }
     }
 
 }

--- a/src/test/kotlin/IOTests.kt
+++ b/src/test/kotlin/IOTests.kt
@@ -39,7 +39,7 @@ class IOTests {
         val signalOut = testDir.resolve(signalFilename)
 
         val runConfig = ZRunConfig(
-            pileUpInputs = listOf(PileUpInput(testSamIn, PileUpOptions(Strand.BOTH, PileUpAlgorithm.START))),
+            pileUpRunner = BamPileUpRunner(listOf(PileUpInput(testSamIn, PileUpOptions(Strand.BOTH, PileUpAlgorithm.START)))),
             chrFilter = listOf("chr1", "chr2", "chr3").map { it to null }.toMap(),
             signalOut = SignalOutput(signalOut, SignalOutputType.RAW, SignalOutputFormat.BED_GRAPH),
             fitMode = FitMode.SKEW

--- a/src/test/kotlin/PerformanceTests.kt
+++ b/src/test/kotlin/PerformanceTests.kt
@@ -34,7 +34,7 @@ class PerformanceTest {
         val peaksOut = testDir.resolve(peaksFilename)
 
         val runConfig = ZRunConfig(
-            pileUpInputs = listOf(PileUpInput(testSamIn, PileUpOptions(Strand.BOTH, PileUpAlgorithm.START))),
+            pileUpRunner = BamPileUpRunner(listOf(PileUpInput(testSamIn, PileUpOptions(Strand.BOTH, PileUpAlgorithm.START)))),
             signalOut = SignalOutput(signalOut, SignalOutputType.SMOOTHED, SignalOutputFormat.BED_GRAPH),
             peaksOut = peaksOut,
             fitMode = FitMode.SKEW
@@ -54,7 +54,7 @@ class PerformanceTest {
         val testDir = Files.createTempDirectory("zpeaks_test")
         val peaksOut = testDir.resolve(peaksFilename)
         val runConfig = ZRunConfig(
-            pileUpInputs = pileUpInputs,
+            pileUpRunner = BamPileUpRunner(pileUpInputs),
             chrFilter = mapOf(CHR_22 to (30_000_000 until 32_000_000)),
             peaksOut = peaksOut,
             fitMode = FitMode.SKEW
@@ -72,7 +72,7 @@ class PerformanceTest {
         val testDir = Files.createTempDirectory("zpeaks_test")
         val peaksOut = testDir.resolve(peaksFilename)
         val runConfig = ZRunConfig(
-            pileUpInputs = pileUpInputs,
+            pileUpRunner = BamPileUpRunner(pileUpInputs),
             chrFilter = mapOf(CHR_22 to (30_000_000 until 30_500_000)),
             peaksOut = peaksOut,
             fitMode = FitMode.SKEW

--- a/src/test/kotlin/PileUpTests.kt
+++ b/src/test/kotlin/PileUpTests.kt
@@ -23,7 +23,7 @@ class PileUpTests {
         val multiPileUpInputs =
             listOf(MULTI_BAM_1_PATH, MULTI_BAM_2_PATH, MULTI_BAM_3_PATH, MULTI_BAM_4_PATH)
             .map { PileUpInput(it, pileUpOptions) }
-        val multiRunner = BottomUpZRunner(ZRunConfig(multiPileUpInputs))
+        val multiRunner = BottomUpZRunner(ZRunConfig(BamPileUpRunner(multiPileUpInputs)))
         val pileUpsB = multiRunner.pileUp(CHR_22, CHR_22_SIZE, 0 until CHR_22_SIZE)
         assertThat(pileUpsB.chr).isEqualTo(CHR_22)
         val maxBetween0And10mB = pileUpsB.maxBetween(0, 10_000_000)

--- a/src/test/kotlin/Plot.kt
+++ b/src/test/kotlin/Plot.kt
@@ -72,7 +72,7 @@ class Plot {
 }
 
 private fun simpleZRunConfig(pileUpInputs: List<PileUpInput>) = ZRunConfig(
-    pileUpInputs.toList(), null, null, null, 50.0, 6.0)
+    BamPileUpRunner(pileUpInputs), null, null, null, 50.0, 6.0)
 
 private fun singleFileConfig() = simpleZRunConfig(listOf(PileUpInput(TEST_BAM_PATH, PileUpOptions(Strand.BOTH, PileUpAlgorithm.START))))
 
@@ -88,7 +88,6 @@ private fun bigMultiFileConfig() = simpleZRunConfig(
 private fun plotPdf(zRunner: ZRunner, range: IntRange) {
     val displayRange = range withNSteps 1000
 
-    zRunner.prepBams()
     val pileUp = zRunner.pileUp(CHR_22, CHR_22_SIZE, range)
     val bpUnits = BPUnits.MBP
     val pileUpChartData = bpData(displayRange, bpUnits) { pileUp[it].toDouble() }
@@ -114,7 +113,6 @@ private fun plotPdf(zRunner: ZRunner, range: IntRange) {
 }
 
 private fun <T : GaussianParameters> plotSubPeaks(zRunner: ZRunner, range: IntRange, fitter: Fitter<T>) {
-    zRunner.prepBams()
     val pileUp = zRunner.pileUp(CHR_22, CHR_22_SIZE, range)
     val pdf = zRunner.pdf(pileUp)
     val peaks = zRunner.peaks(pdf)

--- a/src/test/kotlin/util/TestFiles.kt
+++ b/src/test/kotlin/util/TestFiles.kt
@@ -21,6 +21,8 @@ const val CHR_22 = "chr22"
 const val CHR_22_SIZE = 48_000_000
 val CHR_FILTER_PATH = getResourcePath("chr_filter.txt")
 
+val MULTICHROM_PILEUP_BEDGRAPH = getResourcePath("multiChrom.pileup.bedGraph")
+
 interface Junk
 
 fun getResourcePath(relativePath: String): Path {


### PR DESCRIPTION
With this, the infrastructure is in place to also be able to use a bigWig instead.